### PR TITLE
Empty body for the custom XML API request problem

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -378,7 +378,7 @@ module.exports = function(config) {
     var route = [options.url, options.method || 'GET', options.headers];
     var body;
     if (options.bodyRoot && options.body) {
-      js2xmlparser(options.bodyRoot, options.body)
+      body = js2xmlparser(options.bodyRoot, options.body)
     }
     t.request(route, callback, body);
   }


### PR DESCRIPTION
I was receiving an error An XML-formatted body is required for this API method, but none was given., this should fix it.

This was the full error I've received:

    {
      "statusCode": 415,
      "headers": {
        "date": "Tue, 29 Nov 2016 20:27:10 GMT",
        "content-type": "application/xml; charset=utf-8",
        "transfer-encoding": "chunked",
        "connection": "close",
        "set-cookie": [
          "__cfduid=df9a974b8f8ce518f5f2fed2ddea370661480451229; expires=Wed, 29-Nov-17 20:27:09 GMT; path=/; domain=.recurly.com; HttpOnly"
        ],
        "x-api-version": "2.4",
        "content-language": "en-US",
        "x-ratelimit-limit": "2000",
        "x-ratelimit-remaining": "1995",
        "x-ratelimit-reset": "1480451520",
        "cache-control": "no-cache",
        "x-request-id": "aom72gj8jf8i3i8crk60",
        "strict-transport-security": "max-age=15552000; includeSubDomains; preload",
        "server": "cloudflare-nginx",
        "cf-ray": "3098cc79bb4446bc-WAW"
      },
      "data": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <symbol>no_body</symbol>\n  <description>An XML-formatted body is required for this API method, but none was given.</description>\n</error>"
    }